### PR TITLE
Added JDK7 Profile for javafx app so that the javafx dependency is only added...

### DIFF
--- a/javafx/pom.xml
+++ b/javafx/pom.xml
@@ -34,11 +34,6 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.1</version>
 		</dependency>
-		<dependency>
-			<groupId>com.oracle</groupId>
-			<artifactId>javafx</artifactId>
-			<version>2.2.51</version>
-		</dependency>
 	</dependencies>
 
 	<profiles>
@@ -107,7 +102,17 @@
 				</plugins>
 			</build>
 		</profile>
-	</profiles>
-
-
+    <profile>
+        <id>java7</id>
+        <activation>
+            <jdk>1.7</jdk>
+        </activation>
+        <dependencies>
+            <dependency>
+              <groupId>com.oracle</groupId>
+              <artifactId>javafx</artifactId>
+              <version>2.2.51</version>
+            </dependency>
+        </dependencies>
+    </profile>
 </project>


### PR DESCRIPTION
... when JDK7 is used. When JDK8 is used you don't need this dependency. 

This way you can build the application even outside of saxsys network (where 'com.oracle:javafx' is hosted) when you have JDK8 installed.
